### PR TITLE
Fix/process-require-@self

### DIFF
--- a/src/rules/convert_require/roblox_require_mode.rs
+++ b/src/rules/convert_require/roblox_require_mode.rs
@@ -80,7 +80,7 @@ impl RobloxRequireMode {
             source_path.display(),
         );
 
-        if let Some((sourcemap, sourcemap_path)) = self
+        let sourcemap_tried = if let Some((sourcemap, sourcemap_path)) = self
             .cached_sourcemap
             .as_ref()
             .zip(self.rojo_sourcemap.as_ref())
@@ -99,9 +99,10 @@ impl RobloxRequireMode {
                 if let Some(instance_path) =
                     sourcemap.get_instance_path(&source_path, &require_relative_to_sourcemap)
                 {
-                    Ok(Some(Arguments::default().with_argument(
-                        instance_path.convert(&self.indexing_style),
-                    )))
+                    return Ok(Some(
+                        Arguments::default()
+                            .with_argument(instance_path.convert(&self.indexing_style)),
+                    ));
                 } else {
                     match (
                         sourcemap.exists(&source_path),
@@ -128,18 +129,19 @@ impl RobloxRequireMode {
                             );
                         }
                     }
-                    Ok(None)
                 }
             } else {
                 log::debug!(
                     "unable to get relative path from sourcemap for `{}`",
                     require_path.display()
                 );
-                Ok(None)
             }
-        } else if let Some(relative_require_path) =
-            get_relative_path(require_path, &source_path, true)?
-        {
+            true
+        } else {
+            false
+        };
+
+        if let Some(relative_require_path) = get_relative_path(require_path, &source_path, true)? {
             log::trace!(
                 "make require path relative to source: `{}`",
                 relative_require_path.display()
@@ -221,14 +223,18 @@ impl RobloxRequireMode {
                 )))
             }
         } else {
-            Err(DarkluaError::custom(format!(
-                concat!(
-                    "unable to convert path `{}` from `{}` without a sourcemap: unable to ",
-                    "make the require path relative to the source file"
-                ),
-                require_path.display(),
-                source_path.display(),
-            )))
+            if sourcemap_tried {
+                Ok(None)
+            } else {
+                Err(DarkluaError::custom(format!(
+                    concat!(
+                        "unable to convert path `{}` from `{}` without a sourcemap: unable to ",
+                        "make the require path relative to the source file"
+                    ),
+                    require_path.display(),
+                    source_path.display(),
+                )))
+            }
         }
     }
 }

--- a/src/rules/require/path_locator.rs
+++ b/src/rules/require/path_locator.rs
@@ -59,7 +59,7 @@ impl super::PathLocator for RequirePathLocator<'_, '_, '_> {
 
             if source_name == "@self" {
                 path = get_relative_parent_path(source).join(components);
-            } else if source_name.starts_with("@") {
+            } else {
                 let mut extra_module_location = self
                     .path_require_mode
                     .get_source(source_name, self.extra_module_relative_location)

--- a/src/rules/require/path_locator.rs
+++ b/src/rules/require/path_locator.rs
@@ -1,7 +1,10 @@
 use std::path::{Path, PathBuf};
 
 use super::{path_iterator, PathRequireMode};
-use crate::{rules::require::path_utils::is_require_relative, utils, DarkluaError, Resources};
+use crate::{
+    rules::require::path_utils::{get_relative_parent_path, is_require_relative},
+    utils, DarkluaError, Resources,
+};
 
 #[derive(Debug)]
 pub(crate) struct RequirePathLocator<'a, 'b, 'resources> {
@@ -43,18 +46,20 @@ impl super::PathLocator for RequirePathLocator<'_, '_, '_> {
             new_path.push(path);
             path = new_path;
         } else if !path.is_absolute() {
-            {
-                let mut components = path.components();
-                let root = components.next().ok_or_else(|| {
-                    DarkluaError::invalid_resource_path(path.display().to_string(), "path is empty")
-                })?;
-                let source_name = utils::convert_os_string(root.as_os_str()).map_err(|err| {
-                    err.context(format!(
-                        "cannot convert source name to utf-8 in `{}`",
-                        path.display(),
-                    ))
-                })?;
+            let mut components = path.components();
+            let root = components.next().ok_or_else(|| {
+                DarkluaError::invalid_resource_path(path.display().to_string(), "path is empty")
+            })?;
+            let source_name = utils::convert_os_string(root.as_os_str()).map_err(|err| {
+                err.context(format!(
+                    "cannot convert source name to utf-8 in `{}`",
+                    path.display(),
+                ))
+            })?;
 
+            if source_name == "@self" {
+                path = get_relative_parent_path(source).join(components);
+            } else if source_name.starts_with("@") {
                 let mut extra_module_location = self
                     .path_require_mode
                     .get_source(source_name, self.extra_module_relative_location)

--- a/tests/rule_tests/convert_require.rs
+++ b/tests/rule_tests/convert_require.rs
@@ -136,6 +136,8 @@ test_rule!(
         => "local module = require(script.Parent['while'])",
     sibling_module_with_name_with_space("local module = require('./a module.lua')")
         => "local module = require(script.Parent['a module'])",
+    sibling_module_with_self("local module = require('@self/module.lua')")
+        => "local module = require(script.Parent.module)",
 );
 
 test_rule!(


### PR DESCRIPTION
### feat(require): Add support for `@self` module paths

This pull request introduces support for the `@self` module path specifier, as proposed in the "Abstract module paths and `init.luau`" RFC. This feature provides an unambiguous way for a module to refer to its own submodules, which is especially important for aligning `require` resolution behavior with existing ecosystem tools like Rojo.

#### Changes

The core of this change is in `path_locator.rs`, which now recognizes require paths that start with `@self`. When such a path is encountered, it is resolved relative to the containing directory of the current script.

For example, a script located at `package/init.luau` can now use `require('@self/foo')` to reliably import `package/foo.luau`.

This PR also includes a small but important refactor in `roblox_require_mode.rs`. The logic has been adjusted to prevent an error when a sourcemap is present but does not contain an entry for the required module. Instead of failing, the resolver will now correctly fall back to other resolution strategies.

This implementation directly addresses the need for an explicit self-referential path, improving cross-environment compatibility for Luau projects.
